### PR TITLE
adjust capistrano deploy

### DIFF
--- a/cookbooks/nginx/templates/etc/nginx/conf.d/vhosts.conf.erb
+++ b/cookbooks/nginx/templates/etc/nginx/conf.d/vhosts.conf.erb
@@ -1,12 +1,12 @@
 upstream unicorn {
-  server unix:/data/<%= node[:system_user_name] %>/<%= node[:app_name] %>/tmp/sockets/unicorn.sock;
+  server unix:/data/<%= node[:system_user_name] %>/<%= node[:app_name] %>/shared/tmp/sockets/unicorn.sock;
 }
 
 server {
   listen 80;
   charset utf-8;
 
-  root /data/<%= node[:system_user_name] %>/<%= node[:app_name] %>/public;
+  root /data/<%= node[:system_user_name] %>/<%= node[:app_name] %>/current/public;
 
   location / {
     proxy_pass http://unicorn;


### PR DESCRIPTION
## 概要

- capistrano deploy時に関わるnginx変更対応

## 詳細

- capistrano deployでunicorn.sockのpathがshared以下になるのでnginxの設定を変更する
- publicもcurrent配下が最新になるのでpathを変更する