### PR TITLE
upgrade mysql to 5.7

### DIFF
--- a/cookbooks/mysql/default.rb
+++ b/cookbooks/mysql/default.rb
@@ -1,13 +1,57 @@
 execute "yum -y remove mysql*"
 
-package "http://dev.mysql.com/get/mysql-community-release-el6-5.noarch.rpm" do
-    not_if 'rpm -q mysql-community-release-el6-5'
+package "https://dev.mysql.com/get/mysql80-community-release-el6-1.noarch.rpm" do
+    not_if 'rpm -q mysql80-community-release-el6-1.noarch'
 end
+remote_file "/etc/yum.repos.d/mysql-community.repo" do
+    source "remote_files/mysql-community.repo"
+    mode '644'
+    owner 'root'
+    group 'root'
+end
+
 package "mysql-community-server"
 package "mysql-community-devel"
 
+template "/etc/my.cnf" do
+    source "remote_files/my.cnf.erb"
+    variables({"validate_password" => ''})
+    mode '644'
+    owner 'root'
+    group 'root'
+end
+
 service "mysqld" do
   action [:enable, :start]
+end
+
+template "/tmp/set_password.sh" do
+    source "remote_files/set_password.sh.erb"
+    variables({"root_password" => node[:secret]['mysql_root_password']})
+    mode '755'
+    owner 'root'
+    group 'root'
+end
+
+execute 'set root password' do
+  command '/tmp/set_password.sh'
+  not_if "mysql -u root --defaults-file=/root/.my.cnf -e 'show databases;'"
+end
+
+template "/etc/my.cnf" do
+    source "remote_files/my.cnf.erb"
+    variables({"validate_password" => 'validate-password=OFF'})
+    mode '644'
+    owner 'root'
+    group 'root'
+end
+
+service "mysqld" do
+    action :restart
+end
+
+file "/tmp/set_password.sh" do
+  action :delete
 end
 
 execute "mysql init" do

--- a/cookbooks/mysql/remote_files/my.cnf.erb
+++ b/cookbooks/mysql/remote_files/my.cnf.erb
@@ -1,0 +1,34 @@
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+innodb_large_prefix
+innodb_file_per_table
+innodb_file_format=Barracuda
+character-set-server=utf8mb4
+<%= @validate_password %>
+
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
+

--- a/cookbooks/mysql/remote_files/mysql-community.repo
+++ b/cookbooks/mysql/remote_files/mysql-community.repo
@@ -1,0 +1,66 @@
+# Enable to use MySQL 5.5
+[mysql55-community]
+name=MySQL 5.5 Community Server
+baseurl=http://repo.mysql.com/yum/mysql-5.5-community/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+# Enable to use MySQL 5.6
+[mysql56-community]
+name=MySQL 5.6 Community Server
+baseurl=http://repo.mysql.com/yum/mysql-5.6-community/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+# Enable to use MySQL 5.7
+[mysql57-community]
+name=MySQL 5.7 Community Server
+baseurl=http://repo.mysql.com/yum/mysql-5.7-community/el/6/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql80-community]
+name=MySQL 8.0 Community Server
+baseurl=http://repo.mysql.com/yum/mysql-8.0-community/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql-connectors-community]
+name=MySQL Connectors Community
+baseurl=http://repo.mysql.com/yum/mysql-connectors-community/el/6/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql-tools-community]
+name=MySQL Tools Community
+baseurl=http://repo.mysql.com/yum/mysql-tools-community/el/6/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql-tools-preview]
+name=MySQL Tools Preview
+baseurl=http://repo.mysql.com/yum/mysql-tools-preview/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:/etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql-cluster-7.5-community]
+name=MySQL Cluster 7.5 Community
+baseurl=http://repo.mysql.com/yum/mysql-cluster-7.5-community/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+
+[mysql-cluster-7.6-community]
+name=MySQL Cluster 7.6 Community
+baseurl=http://repo.mysql.com/yum/mysql-cluster-7.6-community/el/6/$basearch/
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql
+

--- a/cookbooks/mysql/remote_files/set_password.sh.erb
+++ b/cookbooks/mysql/remote_files/set_password.sh.erb
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+tmp_pass=`grep 'temporary password' /var/log/mysqld.log | awk -F'root@localhost: ' '{print $2}'`
+sql="ALTER USER 'root'@'localhost' IDENTIFIED BY '$tmp_pass';SET GLOBAL validate_password_length=1; SET GLOBAL validate_password_policy=LOW;ALTER USER 'root'@'localhost' IDENTIFIED BY '<%= @root_password %>';"
+
+mysql -uroot -p"$tmp_pass" --connect-expired-password -e "$sql"


### PR DESCRIPTION
MySQL 5.7 をインストールするPRです。

## 概要

* MySQL の公式リポジトリを追加し、MySQL 8.0 を無効化、5.7 を有効化
* 5.7 では初回起動時に validate_password プラグインが有効なため、`root` など簡易なパスワードは拒否される。そのため、一度初回起動時に生成されたパスワードでログインし、validate_password プラグインの設定を弱くする（長さだけチェックとし、長さを1文字以上とする）。そのうえで、指定されたパスワードを設定し直す
* 再度 /etc/my.cnf に `validate-password=OFF` を指定して、当該プラグインを無効にして再起動する